### PR TITLE
Adding Flow deserialization

### DIFF
--- a/elasticHandler.go
+++ b/elasticHandler.go
@@ -11,7 +11,7 @@ import (
 // converts to json and send data to elastic
 //Refer https://github.com/dvas0004/GolangSimpleDnsSniffer
 // ToDo: Use WaitGroups
-func sendToElastic(data deserializedPacket, wg *sync.WaitGroup) {
+func sendPacketToElastic(data deserializedPacket, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	var jsonMsg, jsonErr = json.Marshal(data)
@@ -37,5 +37,10 @@ func sendToElastic(data deserializedPacket, wg *sync.WaitGroup) {
 	}
 
 	defer resp.Body.Close()
+
+}
+
+func sendFlowToElastic(data deserializedFlow, wg *sync.WaitGroup) {
+	// TODO
 
 }

--- a/flowDeserializer.go
+++ b/flowDeserializer.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/google/gopacket"
+)
+
+// Struct to be indexed in ElasticSearch
+type deserializedFlow struct {
+	Src          gopacket.Endpoint
+	Dest         gopacket.Endpoint
+	FlowHash     []byte
+	EndpointType gopacket.EndpointType
+}
+
+// Utility function which returns deserializedFlow object from the input packet
+func flowDeserializer(packet gopacket.Packet) deserializedFlow {
+	netFlow := packet.NetworkLayer().NetworkFlow()
+	src, dst := netFlow.Endpoints()
+	endType := netFlow.EndpointType()
+	flowHash := computeFlowHash(netFlow)
+	sFlow := deserializedFlow{src, dst, flowHash, endType}
+	return sFlow
+}

--- a/main.go
+++ b/main.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"errors"
-	"log"
-	"net"
-
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
+	"log"
+	"net"
 )
 
 // Borrowed from examples https://github.com/google/gopacket/blob/0ad7f2610e344e58c1c95e2adda5c3258da8e97b/examples/arpscan/arpscan.go#L58


### PR DESCRIPTION
Since we will be considering only NetworkFlow, it was better to just simply compute a hash of the Flow object which can be used to map each packet to a flow.
Ref: https://godoc.org/github.com/google/gopacket#Flow

Please let me know your view on this @darshkpatel 